### PR TITLE
update keycloak configs to avoid deployment error

### DIFF
--- a/configuration/testrealm.json
+++ b/configuration/testrealm.json
@@ -4,7 +4,7 @@
     "accessTokenLifespan": 3000,
     "accessCodeLifespan": 10,
     "accessCodeLifespanUserAction": 6000,
-    "sslNotRequired": true,
+    "sslRequired": "external",
     "registrationAllowed": false,
     "social": false,
     "updateProfileOnInitialSocialLogin": false,
@@ -21,7 +21,8 @@
             "credentials" : [
                 { "type" : "password",
                   "value" : "password" }
-            ]
+            ],
+            "realmRoles": [ "user" ]
         }
     ],
     "roles" : {
@@ -36,12 +37,6 @@
             }
         ]
     },
-    "roleMappings": [
-        {
-            "username": "testuser@redhat.com",
-            "roles": ["user"]
-        }
-    ],
     "scopeMappings": [
         {
             "client": "product-inventory",

--- a/src/main/webapp/WEB-INF/keycloak.json
+++ b/src/main/webapp/WEB-INF/keycloak.json
@@ -2,7 +2,7 @@
     "realm": "product-inventory",
     "realm-public-key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCrVrCuTtArbgaZzL1hvh0xtL5mc7o0NqPVnYXkLvgcwiC3BjLGw1tGEGoJaXDuSaRllobm53JBhjx33UNv+5z/UMG4kytBWxheNVKnL6GgqlNabMaFfPLPCF8kAgKnsi79NMo+n6KnSY8YeUmec/p2vjO2NjsSAVcWEQMVhJ31LwIDAQAB",
     "auth-server-url": "http://localhost:8080/auth",
-    "ssl-not-required": true,
+    "ssl-required": "external",
     "resource": "product-inventory",
     "public-client": true
 }


### PR DESCRIPTION
keycloak complaining for not existing fields and failed to deploy war,  probably the specific fields got outdated and replaced in the latest keycloak version This PR replaces the outdated fields with the correct ones.
